### PR TITLE
external_dns can be enabled in annotations

### DIFF
--- a/deploy/example-service.yaml
+++ b/deploy/example-service.yaml
@@ -21,8 +21,10 @@ metadata:
   name: my-nginx
   labels:
     run: my-nginx
-    external_dns: "true"
+    # external_dns value is checked both in labels and in annotations
+    #external_dns: "true"
   annotations:
+    external_dns: "true"
     external_dns_hostname: "example-nginx"
 spec:
   ports:


### PR DESCRIPTION
To be able to configure kube2clouddns without having access to service
labels, this change allows external_dns: "true" to be specified as an
annotation.

This is for helm chart use case, where charts expose annotations for
integration configuration, but not labels.

INF-6425