### PR TITLE
Two stage docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,12 @@
-FROM alpine:3.6
-ENV GOPATH /go
-ENV PACKAGE github.com/tomologic/kube2clouddns/
-ENV PROJECT_HOME $GOPATH/src/$PACKAGE
-RUN mkdir -p $PROJECT_HOME
-WORKDIR $PROJECT_HOME
-COPY glide.yaml $PROJECT_HOME
-COPY glide.lock $PROJECT_HOME
-COPY *.go $PROJECT_HOME
+FROM golang:1.9-alpine as builder
+WORKDIR /go/src/kube2clouddns
+RUN apk --no-cache add glide git
+COPY glide.* ./
+RUN glide install
+COPY *.go ./
+RUN go build -v
 
-RUN apk --no-cache add -t deps --update gcc git openssl ca-certificates musl-dev \
-    && export GOPATH=/go \
-    && apk --no-cache add -t deps --update --repository http://dl-cdn.alpinelinux.org/alpine/edge/community go glide  \
-    && glide install \
-    #&& go build -v \
-    && go install \
-    && cp /go/bin/* /usr/bin/ \
-    && rm -rf /go $HOME/.glide \
-    && apk del --purge deps; rm -rf /tmp/* /var/cache/apk/*
+FROM alpine:3.6
+COPY --from=builder /go/src/kube2clouddns/kube2clouddns /usr/bin/
 
 ENTRYPOINT ["kube2clouddns"]


### PR DESCRIPTION
Instead of installing build dependencies in run container only to remove
them, let's build in a golang image then copy the binary to a tiny
alpine image. Makes for a shorter Dockerfile.