### PR TITLE
Don't make needless DNS updates

### DIFF
--- a/main.go
+++ b/main.go
@@ -34,6 +34,11 @@ func (client *DnsUpdater) serviceDeleted(obj interface{}) {
 func (client *DnsUpdater) serviceUpdated(oldObj, newObj interface{}) {
 	oldService := oldObj.(*v1.Service)
 	newService := newObj.(*v1.Service)
+
+	if newService.ObjectMeta.ResourceVersion == oldService.ObjectMeta.ResourceVersion {
+		return // Service unchanged, no need to update DNS
+	}
+
 	log.Println("Service updated from: " + oldService.ObjectMeta.Name + " to: " + newService.ObjectMeta.Name)
 	client.upsertService(newService)
 	if oldService.Name != newService.Name {


### PR DESCRIPTION
A kubernetes watch update event does not mean that anything has actually
changed. Proper monitoring of kube changes is to check the resource
version. When a manifest change happens, the service version is updated.

As such, to avoid needlessly spamming Google's DNS API endpoint, a guard
is added to ensure we only update the DNS record when a service's
resource version has changed.